### PR TITLE
fix: use absolute path for importing plan assets

### DIFF
--- a/src/actions/link.js
+++ b/src/actions/link.js
@@ -47,7 +47,7 @@ module.exports = function link(progressListener, source) {
         if (assetInfo.kind === 'core/plan') {
 
             //Asset is a plan - we need to link any locally defined assets as well
-            const assetFiles = glob.sync('*/**/kapeta.yml', {cwd: resolvedPath});
+            const assetFiles = glob.sync('*/**/kapeta.yml', {cwd: resolvedPath, absolute: true});
             if (assetFiles.length > 0) {
                 progressListener.info('Linking local plan asset');
                 assetFiles.forEach(assetFile => {


### PR DESCRIPTION
Linking sub-assets with a relative path (without leading slash), results in trying to import it from user homedir when used from the electron app. Always using absolute imports should work everywhere.